### PR TITLE
Fix deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.1.0 (TBA)
+* Adapt behaviour when retrieving last error from stamps due to [symfony/symfony#32904](https://github.com/symfony/symfony/pull/32904) (#5)
+
 ## 1.0.0 (2020-07-08)
 First release of this package; features include:
  - A Symfony Messenger transport that relies on MongoDB, using [`facile-it/mongodb-bundle`](https://github.com/facile-it/mongodb-bundle/)

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "ext-mongodb": "^1.1.5",
         "facile-it/mongodb-bundle": "^0.6 || ^1.0.0",
         "mongodb/mongodb": "^1.1.0",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/framework-bundle": "^4.4 || ^5.0",
         "symfony/messenger": "^4.4 || ^5.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,6 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
     </php>
 
     <testsuites>

--- a/src/Util/RedeliveryStampExtractor.php
+++ b/src/Util/RedeliveryStampExtractor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Facile\MongoDbMessenger\Util;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 
 /**
@@ -14,6 +15,8 @@ class RedeliveryStampExtractor
 {
     public static function getFirstWithException(Envelope $envelope): ?RedeliveryStamp
     {
+        self::checkDeprecation();
+
         /** @var RedeliveryStamp $stamp */
         foreach ($envelope->all(RedeliveryStamp::class) as $stamp) {
             if (null !== $stamp->getExceptionMessage()) {
@@ -26,6 +29,8 @@ class RedeliveryStampExtractor
 
     public static function getLastWithException(Envelope $envelope): ?RedeliveryStamp
     {
+        self::checkDeprecation();
+
         /** @var RedeliveryStamp $stamp */
         foreach (array_reverse($envelope->all(RedeliveryStamp::class)) as $stamp) {
             if (null !== $stamp->getExceptionMessage()) {
@@ -34,5 +39,16 @@ class RedeliveryStampExtractor
         }
 
         return null;
+    }
+
+    private static function checkDeprecation(): void
+    {
+        if (class_exists(ErrorDetailsStamp::class)) {
+            trigger_deprecation(
+                'symfony/messenger',
+                '5.2',
+                'using RedeliveryStamp::getExceptionMessage is deprecated; use ErrorDetailsStamp instead, which is now added to failed messages to retain information about the failures'
+            );
+        }
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -142,6 +142,9 @@
     "psr/container": {
         "version": "1.0.0"
     },
+    "psr/event-dispatcher": {
+        "version": "1.0.0"
+    },
     "psr/log": {
         "version": "1.1.3"
     },
@@ -210,9 +213,6 @@
         "files": [
             "bin/console"
         ]
-    },
-    "symfony/debug": {
-        "version": "v4.4.19"
     },
     "symfony/dependency-injection": {
         "version": "v5.1.5"
@@ -314,6 +314,12 @@
     "symfony/polyfill-ctype": {
         "version": "v1.18.1"
     },
+    "symfony/polyfill-intl-grapheme": {
+        "version": "v1.22.1"
+    },
+    "symfony/polyfill-intl-normalizer": {
+        "version": "v1.22.1"
+    },
     "symfony/polyfill-mbstring": {
         "version": "v1.18.1"
     },
@@ -354,6 +360,9 @@
     },
     "symfony/stopwatch": {
         "version": "v5.1.5"
+    },
+    "symfony/string": {
+        "version": "v5.2.3"
     },
     "symfony/var-dumper": {
         "version": "v5.1.5"

--- a/tests/End2End/MongoDbTransportTest.php
+++ b/tests/End2End/MongoDbTransportTest.php
@@ -15,7 +15,6 @@ use MongoDB\Model\BSONDocument;
 use MongoDB\Model\CollectionInfo;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
 
 class MongoDbTransportTest extends WebTestCase
@@ -88,9 +87,6 @@ class MongoDbTransportTest extends WebTestCase
             $this->assertSame('failed', $document->queueName);
             $this->assertTrue(property_exists($document, 'foo'));
             $this->assertSame('bar', $document->foo);
-            if (class_exists(ErrorDetailsStamp::class)) {
-                $this->markTestIncomplete('Need to switch to ErrorDetailsStamp since Symfony 5.2');
-            }
             $this->assertTrue(property_exists($document, 'lastErrorMessage'));
             $this->assertSame(FooHandler::ERROR_MESSAGE, $document->lastErrorMessage);
         }

--- a/tests/Unit/Extension/DocumentEnhancer/FirstErrorMessageEnhancerTest.php
+++ b/tests/Unit/Extension/DocumentEnhancer/FirstErrorMessageEnhancerTest.php
@@ -7,22 +7,36 @@ namespace Facile\MongoDbMessenger\Tests\Unit\Extension\DocumentEnhancer;
 use Facile\MongoDbMessenger\Extension\DocumentEnhancer\FirstErrorMessageEnhancer;
 use MongoDB\Model\BSONDocument;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 
 class FirstErrorMessageEnhancerTest extends DocumentEnhancerTestCase
 {
     public function testEnhance(): void
     {
+        if (class_exists(ErrorDetailsStamp::class)) {
+            // Symfony 5.2+
+            $stamps = [
+                $stamp = new RedeliveryStamp(456),
+                new ErrorDetailsStamp(\Exception::class, 500, 'Foo Bar'),
+                new RedeliveryStamp(789),
+                new ErrorDetailsStamp(\Exception::class, 500, 'Baz'),
+            ];
+        } else {
+            $stamps = [
+                $stamp = new RedeliveryStamp(456, 'Foo Bar'),
+                new RedeliveryStamp(789, 'Baz'),
+            ];
+        }
+
         $document = new BSONDocument();
-        $stamp = new RedeliveryStamp(456, 'Foo Bar');
-        $stampToBeIgnored = new RedeliveryStamp(789, 'Baz');
         $envelope = new Envelope(new class() {
-        }, [$stamp, $stampToBeIgnored]);
+        }, $stamps);
 
         (new FirstErrorMessageEnhancer())->enhance($document, $envelope);
 
         $this->assertPropertyEquals($stamp->getRedeliveredAt(), $document, 'firstErrorAt');
-        $this->assertPropertyEquals($stamp->getExceptionMessage(), $document, 'firstErrorMessage');
+        $this->assertPropertyEquals('Foo Bar', $document, 'firstErrorMessage');
         $this->assertPropertyDoesNotExist('retryCount', $document);
     }
 

--- a/tests/Unit/Extension/DocumentEnhancer/LastErrorMessageEnhancerTest.php
+++ b/tests/Unit/Extension/DocumentEnhancer/LastErrorMessageEnhancerTest.php
@@ -24,8 +24,8 @@ class LastErrorMessageEnhancerTest extends DocumentEnhancerTestCase
             ];
         } else {
             $stamps = [
-                $stamp = new RedeliveryStamp(456, 'Foo Bar'),
-                new RedeliveryStamp(789, 'Baz'),
+                $stamp = new RedeliveryStamp(456, 'Baz'),
+                new RedeliveryStamp(789, 'Foo Bar'),
             ];
         }
 

--- a/tests/Unit/Extension/DocumentEnhancer/LastErrorMessageEnhancerTest.php
+++ b/tests/Unit/Extension/DocumentEnhancer/LastErrorMessageEnhancerTest.php
@@ -17,15 +17,15 @@ class LastErrorMessageEnhancerTest extends DocumentEnhancerTestCase
         if (class_exists(ErrorDetailsStamp::class)) {
             // Symfony 5.2+
             $stamps = [
-                $stamp = new RedeliveryStamp(456),
+                new RedeliveryStamp(456),
                 new ErrorDetailsStamp(\Exception::class, 500, 'Baz'),
                 $stamp = new RedeliveryStamp(789),
                 new ErrorDetailsStamp(\Exception::class, 500, 'Foo Bar'),
             ];
         } else {
             $stamps = [
-                $stamp = new RedeliveryStamp(456, 'Baz'),
-                new RedeliveryStamp(789, 'Foo Bar'),
+                new RedeliveryStamp(456, 'Baz'),
+                $stamp = new RedeliveryStamp(789, 'Foo Bar'),
             ];
         }
 

--- a/tests/Unit/Extension/DocumentEnhancer/LastErrorMessageEnhancerTest.php
+++ b/tests/Unit/Extension/DocumentEnhancer/LastErrorMessageEnhancerTest.php
@@ -7,22 +7,36 @@ namespace Facile\MongoDbMessenger\Tests\Unit\Extension\DocumentEnhancer;
 use Facile\MongoDbMessenger\Extension\DocumentEnhancer\LastErrorMessageEnhancer;
 use MongoDB\Model\BSONDocument;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 
 class LastErrorMessageEnhancerTest extends DocumentEnhancerTestCase
 {
     public function testEnhance(): void
     {
+        if (class_exists(ErrorDetailsStamp::class)) {
+            // Symfony 5.2+
+            $stamps = [
+                $stamp = new RedeliveryStamp(456),
+                new ErrorDetailsStamp(\Exception::class, 500, 'Baz'),
+                $stamp = new RedeliveryStamp(789),
+                new ErrorDetailsStamp(\Exception::class, 500, 'Foo Bar'),
+            ];
+        } else {
+            $stamps = [
+                $stamp = new RedeliveryStamp(456, 'Foo Bar'),
+                new RedeliveryStamp(789, 'Baz'),
+            ];
+        }
+
         $document = new BSONDocument();
-        $stampToBeIgnored = new RedeliveryStamp(456, 'Baz');
-        $stamp = new RedeliveryStamp(789, 'Foo Bar');
         $envelope = new Envelope(new class() {
-        }, [$stampToBeIgnored, $stamp]);
+        }, $stamps);
 
         (new LastErrorMessageEnhancer())->enhance($document, $envelope);
 
         $this->assertPropertyEquals($stamp->getRedeliveredAt(), $document, 'lastErrorAt');
-        $this->assertPropertyEquals($stamp->getExceptionMessage(), $document, 'lastErrorMessage');
+        $this->assertPropertyEquals('Foo Bar', $document, 'lastErrorMessage');
         $this->assertPropertyEquals($stamp->getRetryCount(), $document, 'retryCount');
     }
 


### PR DESCRIPTION
`symfony/messenger` marks errors in stamps in a different way since 5.2, see https://github.com/symfony/symfony/pull/32904

This requires adaptation on the DocumentEnhancers.