### PR TITLE
Force typeMap['root'] to BSONDocument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.3.0 (TBA)
+* Force typeMap['root] to BSONDocument ([#8](https://github.com/facile-it/mongodb-messenger-transport/issues/8))
+
 ## 1.2.0 (TBA)
 * Allow PHP 8 (#9)
 * Drop support for PHP 7.2 (#9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## 1.3.0 (TBA)
-* Force typeMap['root] to BSONDocument ([#8](https://github.com/facile-it/mongodb-messenger-transport/issues/8))
+* Force `typeMap['root']` to `BSONDocument` ([#8](https://github.com/facile-it/mongodb-messenger-transport/issues/8))
 
 ## 1.2.0 (TBA)
 * Allow PHP 8 (#9)

--- a/src/Transport/Connection.php
+++ b/src/Transport/Connection.php
@@ -64,6 +64,7 @@ final class Connection
         $options['sort'] = [
             'availableAt' => 1,
         ];
+        $options = $this->setTypeMapOption($options);
 
         $updateStatement = [
             '$set' => [
@@ -170,7 +171,7 @@ final class Connection
      */
     public function find(string $id): ?BSONDocument
     {
-        return $this->collection->findOne(['_id' => new ObjectId($id)]);
+        return $this->collection->findOne(['_id' => new ObjectId($id)], $this->setTypeMapOption());
     }
 
     /**
@@ -194,7 +195,7 @@ final class Connection
      */
     public function findBy($filters, array $options): Cursor
     {
-        return $this->collection->find($filters, $options);
+        return $this->collection->find($filters, $this->setTypeMapOption($options));
     }
 
     /**
@@ -254,5 +255,19 @@ final class Connection
         return [
             'writeConcern' => new WriteConcern(WriteConcern::MAJORITY),
         ];
+    }
+
+    /**
+     * @param array<string, mixed> $readOptions
+     *
+     * @return array<string, mixed>
+     */
+    private function setTypeMapOption(array $readOptions = []): array
+    {
+        $readOptions['typeMap'] = [
+            'root' => BSONDocument::class,
+        ];
+
+        return $readOptions;
     }
 }


### PR DESCRIPTION
To prevent BC breaks, force the root to BSONDocument...
See https://github.com/facile-it/mongodb-bundle/issues/116

Not sure if this is a valid solution??